### PR TITLE
Fix screen timeout and improve widget sync reliability

### DIFF
--- a/app/src/main/java/com/antigravity/transparentcalendar/BootReceiver.kt
+++ b/app/src/main/java/com/antigravity/transparentcalendar/BootReceiver.kt
@@ -22,6 +22,9 @@ class BootReceiver : BroadcastReceiver() {
             
             // Reschedule all upcoming alarms
             EventAlarmScheduler.scheduleUpcomingAlarms(context)
+
+            // Reschedule the calendar monitoring job
+            CalendarUpdateJobService.scheduleJob(context)
         }
     }
 }

--- a/app/src/main/java/com/antigravity/transparentcalendar/CalendarUpdateJobService.kt
+++ b/app/src/main/java/com/antigravity/transparentcalendar/CalendarUpdateJobService.kt
@@ -24,6 +24,12 @@ class CalendarUpdateJobService : JobService() {
                         JobInfo.TriggerContentUri.FLAG_NOTIFY_FOR_DESCENDANTS
                     )
                 )
+                .addTriggerContentUri(
+                    JobInfo.TriggerContentUri(
+                        android.provider.CalendarContract.Calendars.CONTENT_URI,
+                        JobInfo.TriggerContentUri.FLAG_NOTIFY_FOR_DESCENDANTS
+                    )
+                )
                 // Add a small delay to batch updates if multiple changes happen quickly
                 .setTriggerContentUpdateDelay(500) 
                 .setTriggerContentMaxDelay(2000)

--- a/app/src/main/java/com/antigravity/transparentcalendar/NotificationActivity.kt
+++ b/app/src/main/java/com/antigravity/transparentcalendar/NotificationActivity.kt
@@ -69,7 +69,8 @@ class NotificationActivity : Activity() {
         }
         
         // Keep screen on while this activity is visible
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // Removed to allow screen timeout
+        // window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
     
     private fun setupUI() {


### PR DESCRIPTION
This PR addresses two issues:
1. The full-screen notification was keeping the screen on indefinitely. By removing `FLAG_KEEP_SCREEN_ON`, the screen will now turn off after the system timeout period.
2. Widget updates were not triggering reliably for some calendar changes (e.g. adding events via web client). By adding `CalendarContract.Calendars.CONTENT_URI` to the `JobScheduler` trigger and ensuring the job is rescheduled on boot, the widget should now update more reliably without polling.

---
*PR created automatically by Jules for task [3824804099968988291](https://jules.google.com/task/3824804099968988291) started by @WinterSoldier13*